### PR TITLE
Add delmap command

### DIFF
--- a/src/fpsgame/client.cpp
+++ b/src/fpsgame/client.cpp
@@ -2207,5 +2207,15 @@ namespace game
         player1->resetinterp();
     }
     COMMAND(gotosel, "");
+	
+    void delmap(const char* mname)
+    {
+        defformatstring(fname)("%s%s.ogz", strstr(mname, "/") ? "" : "packages/base/", mname);
+        if(remove(findfile(fname, "rb")) != 0)
+            conoutf(CON_ERROR, "could not find \"%s\" map file", fname);
+        else
+            conoutf(CON_WARN, "map \f8%s \f~successfully deleted", mname);
+    }
+    COMMAND(delmap, "s");
 }
 


### PR DESCRIPTION
delmap deletes a map from a given directory
usage:
`/delmap mapname`
or
`/delmap any/folder/mapname`
if there is no folder, "packages/base" will be used by default

- [x] my contribution will be licensed under [ZLIB](https://www.zlib.net/zlib_license.html) (for code)
