### PR TITLE
Add getmodeinfo command

### DIFF
--- a/src/fpsgame/client.cpp
+++ b/src/fpsgame/client.cpp
@@ -541,6 +541,10 @@ namespace game
     }
     ICOMMAND(mode, "i", (int *val), setmode(*val));
     ICOMMAND(getmode, "", (), intret(gamemode));
+    ICOMMAND(getmodeinfo, "i", (int *m), {
+        if (*m < 0 || *m >= 23) return;
+        result(gamemodes[*m + 3].info);
+    });
     ICOMMAND(timeremaining, "i", (int *formatted), 
     {
         int val = max(maplimit - lastmillis + 999, 0)/1000;

--- a/src/fpsgame/client.cpp
+++ b/src/fpsgame/client.cpp
@@ -541,7 +541,8 @@ namespace game
     }
     ICOMMAND(mode, "i", (int *val), setmode(*val));
     ICOMMAND(getmode, "", (), intret(gamemode));
-    ICOMMAND(getmodeinfo, "i", (int *m), {
+    ICOMMAND(getmodeinfo, "i", (int *m),
+    {
         if (*m < 0 || *m >= 23) return;
         result(gamemodes[*m + 3].info);
     });


### PR DESCRIPTION
- [x] my contribution will be licensed under [ZLIB](https://www.zlib.net/zlib_license.html) (for code)

`getmodeinfo I`
returns game mode description based on its index
### usage:
`/echo (getmodeinfo 2)`
"Teamplay: Collect items for ammo. Frag the enemy team to score points for your team."
or
`/echo (getmodeinfo (indexof $modenames "teamplay"))`

