### PR TITLE
Allow floating-point values for `crosshairsize`

### DIFF
--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -2069,7 +2069,7 @@ void drawdamagescreen(int w, int h)
 VAR(hidestats, 0, 0, 1);
 VAR(hidehud, 0, 0, 1);
 
-VARP(crosshairsize, 0, 15, 50);
+FVARP(crosshairsize, 0, 15, 50);
 VARP(cursorsize, 0, 30, 50);
 VARP(crosshairfx, 0, 1, 1);
 VARP(crosshaircolors, 0, 1, 1);


### PR DESCRIPTION
This makes finer size adjustments possible.