### PR TITLE
Increase `minimapsize`, `reflectsize` and `shadowmapsize` limits

### DIFF
--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -1668,7 +1668,7 @@ HVARFR(minimapcolour, 0, 0, 0xFFFFFF,
     minimapcolor = bvec((minimapcolour>>16)&0xFF, (minimapcolour>>8)&0xFF, minimapcolour&0xFF);
 });
 VARR(minimapclip, 0, 0, 1);
-VARFP(minimapsize, 7, 8, 10, { if(minimaptex) drawminimap(); });
+VARFP(minimapsize, 7, 8, 11, { if(minimaptex) drawminimap(); });
 
 void bindminimap()
 {

--- a/src/engine/shadowmap.cpp
+++ b/src/engine/shadowmap.cpp
@@ -4,7 +4,7 @@
 VARP(shadowmap, 0, 0, 1);
 
 extern void cleanshadowmap();
-VARFP(shadowmapsize, 7, 9, 11, cleanshadowmap());
+VARFP(shadowmapsize, 7, 9, 12, cleanshadowmap());
 VARP(shadowmapradius, 64, 96, 256);
 VAR(shadowmapheight, 0, 32, 128);
 VARP(shadowmapdist, 128, 256, 512);

--- a/src/engine/water.cpp
+++ b/src/engine/water.cpp
@@ -568,7 +568,7 @@ void cleanreflections()
     }
 }
 
-VARFP(reflectsize, 6, 8, 10, cleanreflections());
+VARFP(reflectsize, 6, 8, 11, cleanreflections());
 
 void genwatertex(GLuint &tex, GLuint &fb, GLuint &db, bool refract = false)
 {


### PR DESCRIPTION
These values should work just fine on today's modern systems.