### PR TITLE
Update `.gitignore` to work on Linux, ignore data directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,15 @@
 *.a
 *.lib
 
+# Data directories (should be copied or symlinked from https://github.com/tomatenquark/essential)
+/data
+/packages
+
 # Executables
 *.exe
 *.out
 *.app
-
+tomaten_client
+tomaten_server
+native_client
+native_server


### PR DESCRIPTION
I had to add these entries to prevent Git from tracking generated files or data directories I symlinked from the `essential` repository.