### PR TITLE
Improve player number coloring in the server browser

### DIFF
--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -1174,6 +1174,24 @@ namespace game
 
     bool serverinfoentry(g3d_gui *g, int i, const char *name, int port, const char *sdesc, const char *map, int ping, const vector<int> &attr, int np)
     {
+        const char* playerscolor;
+        if(attr.length() >= 4) {
+            if(np >= attr[3]) {
+                // full server
+                playerscolor = "\f3";
+            } else if (np > attr[3] - 1) {
+                // almost full server (only one slot left)
+                playerscolor = "\f2";
+            } else if (np <= 0) {
+                // empty server
+                playerscolor = "\f4";
+            } else {
+                playerscolor = "";
+            }
+        } else {
+            playerscolor = "";
+        }
+
         if(ping < 0 || attr.empty() || attr[0]!=PROTOCOL_VERSION)
         {
             switch(i)
@@ -1221,7 +1239,7 @@ namespace game
             case 1:
                 if(attr.length()>=4)
                 {
-                    if(g->buttonf(np >= attr[3] ? "\f3%d/%d " : "%d/%d ", 0xFFFFDD, NULL, np, attr[3])&G3D_UP) return true;
+                    if(g->buttonf("%s%d/%d ", 0xFFFFDD, NULL, playerscolor, np, attr[3])&G3D_UP) return true;
                 }
                 else if(g->buttonf("%d ", 0xFFFFDD, NULL, np)&G3D_UP) return true;
                 break;
@@ -1280,4 +1298,3 @@ namespace game
         execfile("auth.cfg", false);
     }
 }
-


### PR DESCRIPTION
- Servers with only one available slot now have their player count displayed in yellow.
- Empty servers now have their player count grayed out.