### PR TITLE
Make variables identified by '_' non-persistent

### DIFF
--- a/src/engine/command.cpp
+++ b/src/engine/command.cpp
@@ -2295,7 +2295,7 @@ void writecfg(const char *name)
     loopv(ids)
     {
         ident &id = *ids[i];
-        if(id.type==ID_ALIAS && id.flags&IDF_PERSIST && !(id.flags&IDF_OVERRIDDEN)) switch(id.valtype)
+        if(escapeid(id)[0] != '_' && id.type==ID_ALIAS && id.flags&IDF_PERSIST && !(id.flags&IDF_OVERRIDDEN)) switch(id.valtype)
         {
         case VAL_STR:
             if(!id.val.s[0]) break;


### PR DESCRIPTION
- [x] my contribution will be licensed under [ZLIB](https://www.zlib.net/zlib_license.html) (for code)

Makes variables like `_myvar = "hello"` temporary, not saving them in **config.cfg** on exit.

This is useful to prevent some variables from going through the "escapestring" function, which removes or replaces characters and sometimes causes problems.