### PR TITLE
Increase the network update rate to ~66.67 Hz

### DIFF
--- a/src/fpsgame/client.cpp
+++ b/src/fpsgame/client.cpp
@@ -1107,7 +1107,7 @@ namespace game
     void c2sinfo(bool force) // send update to the server
     {
         static int lastupdate = -1000;
-        if(totalmillis - lastupdate < 33 && !force) return; // don't update faster than 30fps
+        if(totalmillis - lastupdate < 15 && !force) return; // don't update faster than ~66.67fps
         lastupdate = totalmillis;
         sendpositions();
         sendmessages();

--- a/src/fpsgame/server.cpp
+++ b/src/fpsgame/server.cpp
@@ -1768,9 +1768,9 @@ namespace server
     {
         if(clients.empty() || (!hasnonlocalclients() && !demorecord)) return false;
         enet_uint32 curtime = enet_time_get()-lastsend;
-        if(curtime<33 && !force) return false;
+        if(curtime<15 && !force) return false;
         bool flush = buildworldstate();
-        lastsend += curtime - (curtime%33);
+        lastsend += curtime - (curtime%15);
         return flush;
     }
 


### PR DESCRIPTION
This should make players appear less jittery. Actions should also be replicated faster.

If desired, we could have a `positionpacketdelay` variable to adjust the rate at which client input packets are sent. It would be bounded between `8` and `15`. This could be used by players with good connections to make themselves appear even less jittery.

This closes #31.