### PR TITLE
Tweak some video/audio settings to better match modern PCs

### DIFF
--- a/src/engine/main.cpp
+++ b/src/engine/main.cpp
@@ -100,7 +100,7 @@ SDL_GLContext glcontext = NULL;
 VARF(scr_w, SCR_MINW, -1, SCR_MAXW, initwarning("screen resolution"));
 VARF(scr_h, SCR_MINH, -1, SCR_MAXH, initwarning("screen resolution"));
 VARF(depthbits, 0, 0, 32, initwarning("depth-buffer precision"));
-VARF(fsaa, -1, -1, 16, initwarning("anti-aliasing"));
+VARF(fsaa, -1, 4, 16, initwarning("anti-aliasing"));
 
 void writeinitcfg()
 {

--- a/src/engine/sound.cpp
+++ b/src/engine/sound.cpp
@@ -162,8 +162,8 @@ bool shouldinitaudio = true;
 SVARF(audiodriver, AUDIODRIVER, { shouldinitaudio = true; initwarning("sound configuration", INIT_RESET, CHANGE_SOUND); });
 VARF(usesound, 0, 1, 1, { shouldinitaudio = true; initwarning("sound configuration", INIT_RESET, CHANGE_SOUND); });
 VARF(soundchans, 1, 32, 128, initwarning("sound configuration", INIT_RESET, CHANGE_SOUND));
-VARF(soundfreq, 0, MIX_DEFAULT_FREQUENCY, 48000, initwarning("sound configuration", INIT_RESET, CHANGE_SOUND));
-VARF(soundbufferlen, 128, 1024, 4096, initwarning("sound configuration", INIT_RESET, CHANGE_SOUND));
+VARF(soundfreq, 0, 44100, 48000, initwarning("sound configuration", INIT_RESET, CHANGE_SOUND));
+VARF(soundbufferlen, 128, 768, 4096, initwarning("sound configuration", INIT_RESET, CHANGE_SOUND));
 
 bool initaudio()
 {

--- a/src/engine/texture.cpp
+++ b/src/engine/texture.cpp
@@ -612,7 +612,7 @@ VARFP(texcompress, 0, 1<<10, 1<<12, initwarning("texture quality", INIT_LOAD));
 VARFP(texcompressquality, -1, -1, 1, setuptexcompress());
 VARFP(trilinear, 0, 1, 1, initwarning("texture filtering", INIT_LOAD));
 VARFP(bilinear, 0, 1, 1, initwarning("texture filtering", INIT_LOAD));
-VARFP(aniso, 0, 0, 16, initwarning("texture filtering", INIT_LOAD));
+VARFP(aniso, 0, 8, 16, initwarning("texture filtering", INIT_LOAD));
 
 extern int usetexcompress;
 


### PR DESCRIPTION
- MSAA 4×
  - Smoothes out edges of opaque surfaces.
- Anisotropic filtering 8×
  - Makes textures look better at oblique angles.
- 44 kHz sound frequency (higher quality)
- Decreased sound buffer length for lower sound latency
  - It could be decreased even further (I use `512` on my PC), but this should be a safe value.