### PR TITLE
Improve the crosshair health color algorithm

### DIFF
--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -1128,8 +1128,12 @@ namespace game
 
         if(crosshair!=1 && !editmode && !m_insta)
         {
-            if(d->health<=25) color = vec(1, 0, 0);
-            else if(d->health<=50) color = vec(1, 0.5f, 0);
+            // color crosshair depending on health
+            if(d->health<=20) color = vec(1, 0, 0);
+            else if(d->health<=60) color = vec(1, (d->health-20)/40.0f, 0);
+            else if(d->health<=100) color = vec(1, 1, (d->health-60)/40.0f);
+            else if(d->health<=200) color = vec((200-d->health)/100.0f, 1, (200-d->health)/100.0f);
+            else color = vec(0, 1, 0);
         }
         if(d->gunwait) color.mul(0.5f);
         return crosshair;


### PR DESCRIPTION
- Change the color smoothly depending on the remaining health.
- Color the crosshair in green (progressively) when going above 100 HP.