### PR TITLE
Draw the normal crosshair when showing the team crosshair

### DIFF
--- a/src/engine/rendergl.cpp
+++ b/src/engine/rendergl.cpp
@@ -2143,6 +2143,17 @@ void drawcrosshair(int w, int h)
             crosshair = crosshairs[index];
         }
         chsize = crosshairsize*w/900.0f;
+        if (index == 1) {
+            // draw the normal crosshair in addition to the teammate crosshair
+            // so the player can still know where they're aiming
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            glBindTexture(GL_TEXTURE_2D, crosshairs[0]->id);
+            hudshader->set();
+            gle::color(color);
+            float x = cx*w - (windowhit ? 0 : chsize/2.0f);
+            float y = cy*h - (windowhit ? 0 : chsize/2.0f);
+            hudquad(x, y, chsize, chsize);
+        }
     }
     if(crosshair->type&Texture::ALPHA) glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     else glBlendFunc(GL_ONE, GL_ONE);

--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -1121,12 +1121,12 @@ namespace game
             dynent *o = intersectclosest(d->o, worldpos, d);
             if(o && o->type==ENT_PLAYER && isteam(((fpsent *)o)->team, d->team))
             {
+                // pointing at teammate, show team crosshair
                 crosshair = 1;
-                color = vec(0, 0, 1);
             }
         }
 
-        if(crosshair!=1 && !editmode && !m_insta)
+        if(!editmode && !m_insta)
         {
             if(d->health<=25) color = vec(1, 0, 0);
             else if(d->health<=50) color = vec(1, 0.5f, 0);


### PR DESCRIPTION
- Keep the current crosshair color when showing the team crosshair. This way, players can still know their health status while aiming at a teammate.

This is inspired by CS:GO's teammate crosshair implementation, which is less invasive than the one currently used in Tomatenquark.