### PR TITLE
Enable `guiclicktab` by default

### DIFF
--- a/src/engine/3dgui.cpp
+++ b/src/engine/3dgui.cpp
@@ -30,7 +30,7 @@ static float cursorx = 0.5f, cursory = 0.5f;
 #define MAXCOLUMNS 16
 
 VARP(guiautotab, 6, 16, 40);
-VARP(guiclicktab, 0, 0, 1);
+VARP(guiclicktab, 0, 1, 1);
 VARP(guifadein, 0, 1, 1);
 
 struct gui : g3d_gui


### PR DESCRIPTION
In most user interface systems, clicking to switch tabs is much more common than just hovering them.