### PR TITLE
Increase the default `maxparticletextdistance` value to 1024

### DIFF
--- a/src/engine/renderparticles.cpp
+++ b/src/engine/renderparticles.cpp
@@ -1161,7 +1161,7 @@ void particle_trail(int type, int fade, const vec &s, const vec &e, int color, f
 }
 
 VARP(particletext, 0, 1, 1);
-VARP(maxparticletextdistance, 0, 128, 10000);
+VARP(maxparticletextdistance, 0, 1024, 10000);
 
 void particle_text(const vec &s, const char *t, int type, int fade, int color, float size, int gravity, int icons)
 {


### PR DESCRIPTION
This prevents player names from suddenly disappearing when players are moderately far away from the camera, which is especially noticeable when zooming in.