### PR TITLE
Add hidehudicons var

### DIFF
--- a/src/fpsgame/fps.cpp
+++ b/src/fpsgame/fps.cpp
@@ -944,9 +944,11 @@ namespace game
     }
 
     VARP(healthcolors, 0, 1, 1);
+    VARP(hidehudicons, 0, 0, 1);
 
     void drawhudicons(fpsent *d)
     {
+        if(hidehudicons) return;
         pushhudmatrix();
         hudmatrix.scale(2, 2, 1);
         flushhudmatrix();


### PR DESCRIPTION
- [x] my contribution will be licensed under [ZLIB](https://www.zlib.net/zlib_license.html) (for code)

This is my suggestion to close #62, similar to hidehud, but hides only the icons (keeping texts and crosshair)

![image](https://user-images.githubusercontent.com/9287152/99826102-ab791680-2b36-11eb-9240-551a3873dbad.png)