### PR TITLE
Add allowsavebasemap var

### DIFF
--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -874,13 +874,15 @@ void loadvslots(stream *f, int numvslots)
     delete[] prev;
 }
 
+VARP(allowsavebasemap, 0, 0, 1);
+
 bool save_world(const char *mname, bool nolms)
 {
     if(!*mname) mname = game::getclientmap();
     setmapfilenames(mname);
     if(savebak) backup(ogzname, bakname);
     stream *f = opengzfile(ogzname, "wb");
-    if(!f) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
+    if(!f || (!allowsavebasemap && strstr(id->getstr(), mname))) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
 
     int numvslots = vslots.length();
     if(!nolms && !multiplayer(false))

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -882,6 +882,7 @@ bool save_world(const char *mname, bool nolms)
     setmapfilenames(mname);
     if(savebak) backup(ogzname, bakname);
     stream *f = opengzfile(ogzname, "wb");
+    ident *id = readident("allmaps");
     if(!f || (!allowsavebasemap && strstr(id->getstr(), mname))) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
 
     int numvslots = vslots.length();

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -883,7 +883,7 @@ bool save_world(const char *mname, bool nolms)
     if(savebak) backup(ogzname, bakname);
     stream *f = opengzfile(ogzname, "wb");
     ident *id = readident("allmaps");
-    if(!f || (!allowsavebasemap && strstr(id->getstr(), mname))) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
+    if (!f || (!allowsavebasemap && listincludes(id->getstr(), mname, strlen(mname)) != -1)) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
 
     int numvslots = vslots.length();
     if(!nolms && !multiplayer(false))

--- a/src/engine/worldio.cpp
+++ b/src/engine/worldio.cpp
@@ -883,7 +883,7 @@ bool save_world(const char *mname, bool nolms)
     if(savebak) backup(ogzname, bakname);
     stream *f = opengzfile(ogzname, "wb");
     ident *id = readident("allmaps");
-    if (!f || (!allowsavebasemap && listincludes(id->getstr(), mname, strlen(mname)) != -1)) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
+    if(!f || (!allowsavebasemap && listincludes(id->getstr(), mname, strlen(mname)) != -1)) { conoutf(CON_WARN, "could not write map to %s", ogzname); return false; }
 
     int numvslots = vslots.length();
     if(!nolms && !multiplayer(false))

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -162,7 +162,7 @@ extern bool validateblock(const char *s);
 extern void explodelist(const char *s, vector<char *> &elems, int limit = -1);
 extern char *indexlist(const char *s, int pos);
 extern int listlen(const char *s);
-extern int listincludes(const char* list, const char* needle, int needlelen);
+extern int listincludes(const char *list, const char *needle, int needlelen);
 extern void printvar(ident *id);
 extern void printvar(ident *id, int i);
 extern void printfvar(ident *id, float f);
@@ -227,7 +227,7 @@ static inline bool insideworld(const ivec &o)
 }
 
 // world
-extern char* mapid;
+extern char *mapid;
 extern bool emptymap(int factor, bool force, const char *mname = "", bool usecfg = true);
 extern bool enlargemap(bool force);
 extern int findentity(int type, int index = 0, int attr1 = -1, int attr2 = -1);

--- a/src/shared/iengine.h
+++ b/src/shared/iengine.h
@@ -162,6 +162,7 @@ extern bool validateblock(const char *s);
 extern void explodelist(const char *s, vector<char *> &elems, int limit = -1);
 extern char *indexlist(const char *s, int pos);
 extern int listlen(const char *s);
+extern int listincludes(const char* list, const char* needle, int needlelen);
 extern void printvar(ident *id);
 extern void printvar(ident *id, int i);
 extern void printfvar(ident *id, float f);


### PR DESCRIPTION
- [x] my contribution will be licensed under [ZLIB](https://www.zlib.net/zlib_license.html) (for code)

`allowsavebasemap 0` comes as default and prevents saving maps that are included in the **allmaps** variable (data/maps.cfg).
I think it solves #61 

~~Edit:
the problem with using `strstr` is that it returns a false positive if, for example, the map name is "abcd" and the player tries to save "abc"... I will be happy if someone can come up with a better solution, otherwise it should not be merged.~~